### PR TITLE
return organisation related info about the user

### DIFF
--- a/database/migrations-local/20250909143100_replace_tenantid_with_companycode.js
+++ b/database/migrations-local/20250909143100_replace_tenantid_with_companycode.js
@@ -1,0 +1,26 @@
+const schema = process.env.DB_SCHEMA || 'public';
+const tableName = 'requests';
+
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  await knex.schema.withSchema(schema).alterTable(tableName, (table) => {
+    table.bigInteger('company_code').nullable();
+    table.dropColumn('tenant_id');
+  });
+};
+
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  await knex.schema.withSchema(schema).alterTable(tableName, (table) => {
+    table.dropColumn('company_code');
+    table.integer('tenant_id').nullable();
+  });
+};
+
+exports.config = { transaction: false };

--- a/database/migrations/20250909143100_replace_tenantid_with_companycode.js
+++ b/database/migrations/20250909143100_replace_tenantid_with_companycode.js
@@ -1,0 +1,26 @@
+const schema = process.env.DB_SCHEMA || 'public';
+const tableName = 'requests';
+
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  await knex.schema.withSchema(schema).alterTable(tableName, (table) => {
+    table.bigInteger('company_code').nullable();
+    table.dropColumn('tenant_id');
+  });
+};
+
+/**
+ * @param { import('knex').Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  await knex.schema.withSchema(schema).alterTable(tableName, (table) => {
+    table.dropColumn('company_code');
+    table.integer('tenant_id').nullable();
+  });
+};
+
+exports.config = { transaction: false };

--- a/services/api.service.ts
+++ b/services/api.service.ts
@@ -8,10 +8,6 @@ import ApiGateway, { IncomingRequest, Route } from 'moleculer-web';
 import { MetaSession, RestrictionType, SessionBlob } from '../types';
 import { User } from './users.service';
 
-export interface UserAuthMeta {
-  session: { user: User; token: string; profile: any };
-}
-
 @Service({
   name: 'api',
   mixins: [ApiGateway],
@@ -136,8 +132,10 @@ export default class ApiService extends moleculer.Service {
 
     ctx.meta.session = {
       token,
+      sid,
       user,
       companyCode: session?.companyCode ?? null,
+      activeOrgCode: session?.activeOrgCode,
       roles: session?.roles ?? null,
     };
     return;

--- a/services/api.service.ts
+++ b/services/api.service.ts
@@ -5,7 +5,7 @@ import cookie from 'cookie';
 import moleculer, { Context } from 'moleculer';
 import { Action, Method, Service } from 'moleculer-decorators';
 import ApiGateway, { IncomingRequest, Route } from 'moleculer-web';
-import { MetaSession, RestrictionType } from '../types';
+import { MetaSession, RestrictionType, SessionBlob } from '../types';
 import { User } from './users.service';
 
 export interface UserAuthMeta {
@@ -114,16 +114,33 @@ export default class ApiService extends moleculer.Service {
       return;
     }
 
-    const data: { id: number } = await verifyToken(token, process.env.ACCESS_JWT_SECRET);
-    if (data?.id) {
-      const user: User = await ctx.call('users.resolve', { id: data.id });
-      if (user) {
-        ctx.meta.session = { token, user };
-        return;
-      }
+    const data: any = await verifyToken(token, process.env.ACCESS_JWT_SECRET);
+    const userId = Number(data?.sub);
+    const sid = data?.sid;
+    if (!userId || !sid) {
+      await ctx.call('auth.finish', { token });
+      return;
     }
 
-    await ctx.call('auth.finish', { token });
+    const user: User = await ctx.call('users.resolve', { id: userId });
+    if (!user) {
+      await ctx.call('auth.finish', { token });
+      return;
+    }
+
+    const session = (await this.broker.cacher?.get(`sess:${sid}`)) as SessionBlob | null;
+    if (!session) {
+      await ctx.call('auth.finish', { token });
+      return;
+    }
+
+    ctx.meta.session = {
+      token,
+      user,
+      companyCode: session?.companyCode ?? null,
+      roles: session?.roles ?? null,
+    };
+    return;
   }
 
   @Method

--- a/services/requests.service.ts
+++ b/services/requests.service.ts
@@ -12,12 +12,11 @@ import {
   CommonFields,
   CommonPopulates,
   FieldHookCallback,
+  MetaSession,
   Table,
 } from '../types';
 import { VISIBLE_TO_CREATOR_OR_ADMIN_SCOPE } from '../utils/scopes';
-import { UserAuthMeta } from './api.service';
 import { Form } from './formTypes.service';
-import { Tenant } from './tenants.service';
 import { User } from './users.service';
 
 export enum RequestStatus {
@@ -35,13 +34,11 @@ interface Fields extends CommonFields {
   status: RequestStatus;
   formType: string;
   form: string;
-  tenant: Tenant['id'];
+  companyCode: string;
   data: any;
 }
 
-interface Populates extends CommonPopulates {
-  tenant: Tenant;
-}
+interface Populates extends CommonPopulates {}
 
 export type Request<
   P extends keyof Populates = never,
@@ -49,10 +46,12 @@ export type Request<
 > = Table<Fields, Populates, P, F>;
 
 const populatePermissions = (field: string) => {
-  return function (ctx: Context<{}, UserAuthMeta>, _values: any, requests: any[]) {
-    const { profile, user } = ctx?.meta?.session;
+  return function (ctx: Context<{}, MetaSession>, _values: any, requests: any[]) {
+    const session = ctx.meta.session;
+    const user = session?.user;
+
     return requests.map((r: any) => {
-      const editingPermissions = this.hasPermissionToEdit(r, user, profile);
+      const editingPermissions = this.hasPermissionToEdit(r, user, session.activeOrgCode ?? null);
       return !!editingPermissions[field];
     });
   };
@@ -104,10 +103,12 @@ const populatePermissions = (field: string) => {
         },
       },
 
-      tenant: {
-        type: 'number',
-        columnName: 'tenantId',
-        populate: 'tenants.resolve',
+      companyCode: {
+        type: 'string',
+        columnName: 'company_code',
+        columnType: 'bigint',
+        immutable: true,
+        set: 'setCompanyCode',
       },
 
       canEdit: {
@@ -142,14 +143,9 @@ export default class extends moleculer.Service {
   hasPermissionToEdit(
     request: any,
     user?: User,
-    profile?: Tenant,
-  ): {
-    edit: boolean;
-    validate: boolean;
-  } {
+    activeOrgCode?: string | null,
+  ): { edit: boolean; validate: boolean } {
     const invalid = { edit: false, validate: false };
-
-    const tenant = request.tenant || request.tenantId;
 
     if (
       !request?.id ||
@@ -161,16 +157,17 @@ export default class extends moleculer.Service {
     }
 
     if (!user?.id) {
-      return {
-        edit: true,
-        validate: true,
-      };
+      return invalid;
     }
 
-    const isCreatedByUser = !tenant && user && user.id === request.createdBy;
-    const isCreatedByTenant = profile && profile.id === tenant;
+    const reqCompany: string | null = request?.companyCode ?? null;
+    const isSelfRow = reqCompany == null && request?.createdBy === user.id;
 
-    if (isCreatedByTenant || isCreatedByUser) {
+    const actor = activeOrgCode ?? null;
+    const isActorOrgMatch =
+      reqCompany != null && actor != null && String(reqCompany) === String(actor);
+
+    if (isSelfRow || isActorOrgMatch) {
       return {
         validate: false,
         edit: [RequestStatus.RETURNED, RequestStatus.DRAFT].includes(request.status),
@@ -224,35 +221,42 @@ export default class extends moleculer.Service {
 
   @Method
   validateStatus({ ctx, value, entity }: FieldHookCallback) {
-    const { user, profile } = ctx.meta.session;
-    if (!value || !user?.id) return true;
+    const s = ctx.meta.session;
+    if (!value || !s?.user?.id) return true;
 
     const error = `Cannot set status with value ${value}`;
+
     if (!entity?.id) {
       return [RequestStatus.CREATED, RequestStatus.DRAFT].includes(value) || error;
     }
 
-    const editingPermissions = this.hasPermissionToEdit(entity, user, profile);
+    const canEdit = this.hasPermissionToEdit(entity, s.user, s.activeOrgCode ?? null).edit;
 
-    if (editingPermissions.edit) {
-      const validTransitions: { [key: string]: RequestStatus[] } = {
-        [RequestStatus.DRAFT]: [RequestStatus.DRAFT, RequestStatus.CREATED],
-        [RequestStatus.RETURNED]: [RequestStatus.SUBMITTED],
-      };
+    if (!canEdit) return error;
 
-      return validTransitions?.[entity?.status]?.includes(value) || error;
-    } else if (editingPermissions.validate) {
-      return (
-        [
-          RequestStatus.REJECTED,
-          RequestStatus.RETURNED,
-          RequestStatus.APPROVED,
-          RequestStatus.COMPLETED,
-        ].includes(value) || error
-      );
-    }
+    const allowed: Record<string, RequestStatus[]> = {
+      [RequestStatus.DRAFT]: [RequestStatus.DRAFT, RequestStatus.CREATED],
+      [RequestStatus.RETURNED]: [RequestStatus.SUBMITTED],
+    };
 
-    return error;
+    return allowed?.[entity.status]?.includes(value) || error;
+  }
+
+  @Method
+  setCompanyCode({ ctx, value, entity }: FieldHookCallback<Request>): string | null {
+    if (entity?.id) return entity.companyCode ?? null;
+
+    const session = (ctx.meta.session ?? {}) as {
+      activeOrgCode?: string | null;
+      companyCode?: string | null;
+    };
+
+    const companyCode = value ?? session.activeOrgCode ?? null;
+    if (companyCode == null) return null;
+
+    const str = String(companyCode).trim();
+
+    return /^\d+$/.test(str) ? str : null;
   }
 
   @Action({

--- a/services/sharePoint.service.ts
+++ b/services/sharePoint.service.ts
@@ -1,8 +1,7 @@
 'use strict';
 import Moleculer, { Context, RestSchema } from 'moleculer';
 import { Action, Method, Service } from 'moleculer-decorators';
-import { throwUploadError } from '../types';
-import { UserAuthMeta } from './api.service';
+import { MetaSession, throwUploadError } from '../types';
 
 @Service({
   name: 'sharepoint',
@@ -132,7 +131,7 @@ export default class SharePointService extends Moleculer.Service {
   async uploadFiles(
     ctx: Context<
       {},
-      { filename: string; mimetype: string; $params: { requestId: string } } & UserAuthMeta
+      { filename: string; mimetype: string; $params: { requestId: string } } & MetaSession
     >,
   ) {
     const token = await this.getToken();

--- a/types/moleculer.ts
+++ b/types/moleculer.ts
@@ -1,6 +1,5 @@
 import { IncomingMessage } from 'http';
 import moleculer, { ActionParamSchema, ActionSchema, Context } from 'moleculer';
-import { UserAuthMeta } from '../services/api.service';
 import { User, UserType } from '../services/users.service';
 
 import { DbAdapter, DbContextParameters, DbServiceSettings } from 'moleculer-db';
@@ -16,7 +15,7 @@ export type MultipartMeta = {
 };
 
 export type FieldHookCallback<T = any> = {
-  ctx: Context<T, UserAuthMeta>;
+  ctx: Context<T, MetaSession>;
   value: any;
   params: T;
   field: any;
@@ -335,8 +334,8 @@ export interface ViispUserRaw {
   name?: string;
   firstName?: string;
   lastName?: string;
-  ak?: string | number;
-  personalCode?: string | number;
+  ak: number;
+  personalCode?: number;
   email?: string;
   phone?: string;
   company?: { code?: string; name?: string; email?: string; phone?: string } | null;
@@ -356,6 +355,7 @@ export interface UserRoles {
 export type SessionBlob = {
   userId: number;
   companyCode: string | null;
+  activeOrgCode: string | null;
   roles: { orgs: { id: number; roles: string[] }[] } | null;
 };
 
@@ -368,8 +368,14 @@ export type ResponseHeadersMeta = {
 export interface MetaSession {
   session?: {
     token: string;
+    sid: string;
     user: User;
     companyCode?: string | null;
+    activeOrgCode?: string | null;
     roles?: UserRoles | null;
   };
+}
+
+export interface ActiveOrgResponse {
+  activeOrgCode: string | null;
 }

--- a/types/moleculer.ts
+++ b/types/moleculer.ts
@@ -346,6 +346,19 @@ export interface ViispUserRaw {
   companyPhone?: string;
 }
 
+export interface UserRoles {
+  orgs: {
+    id: number;
+    roles: string[];
+  }[];
+}
+
+export type SessionBlob = {
+  userId: number;
+  companyCode: string | null;
+  roles: { orgs: { id: number; roles: string[] }[] } | null;
+};
+
 export type ResponseHeadersMeta = {
   $responseHeaders?: Record<string, string>;
   $statusCode?: number;
@@ -356,5 +369,7 @@ export interface MetaSession {
   session?: {
     token: string;
     user: User;
+    companyCode?: string | null;
+    roles?: UserRoles | null;
   };
 }

--- a/utils/scopes.ts
+++ b/utils/scopes.ts
@@ -1,24 +1,25 @@
 import { Context } from 'moleculer';
-import { UserAuthMeta } from '../services/api.service';
+import { MetaSession } from '../types';
 
 export const VISIBLE_TO_CREATOR_OR_ADMIN_SCOPE = {
   names: ['visibleToCreatorOrAdminScope'],
   scopes: {
-    visibleToCreatorOrAdminScope(query: any, ctx: Context<null, UserAuthMeta>, params: any) {
-      const { user, profile } = ctx?.meta?.session || {};
-      if (!user?.id) return query;
-
-      if (profile?.id) {
-        return { ...query, tenant: profile.id };
-      } else {
-        const createdByUserQuery = {
-          createdBy: user?.id,
-          tenant: { $exists: false },
-        };
-        return { ...query, ...createdByUserQuery };
+    visibleToCreatorOrAdminScope(query: any, ctx: Context<null, MetaSession>) {
+      const session = ctx.meta.session;
+      if (!session?.user?.id) {
+        return { ...query, createdBy: -1 };
       }
 
-      return query;
+      const userId = session.user.id;
+      const activeOrgCode = session.activeOrgCode ?? null;
+
+      if (activeOrgCode != null && String(activeOrgCode).trim() !== '') {
+        // Only rows I created for the selected org
+        return { ...query, createdBy: userId, companyCode: activeOrgCode };
+      }
+
+      // No active org, all rows I created with "Fizinis asmuo"
+      return { ...query, createdBy: userId, companyCode: null };
     },
   },
 };


### PR DESCRIPTION
/me endpoint now returns companyCode alongside with any roles he has in other organizations.

If the user has a companyCode it is automatically assumed that he is the administrator of the role and has the ability to delegate other users. The userRoles object contains the roles that the user was delegated to have in other organizations.

This info will be used for choosing delegates in the users own organization and the ability to submit requests in the name of other organizations.

Other changes:

- new bigint companyCode field in requests table instead of tenant_id (migration)
- request filtering will be made by companyCode or absence of it (if user made it as "fizinis asmuo"
- POST and DELETE /session/active-org endpoints for choosing the organization that comes in the "userRoles" object, if user signs in as "fizinis asmuo"
- requests service refactored to use companyCode, and remnants of the unfinished tenants service have been removed