### PR TITLE
REVIEW is editable, exp cert no is forwarded to front correctly

### DIFF
--- a/services/requests.service.ts
+++ b/services/requests.service.ts
@@ -129,7 +129,6 @@ const populatePermissions = (field: string) => {
 
       exportCertificateNo: {
         type: 'string',
-        columnName: 'export_certificate_no',
       },
 
       completedAt: {
@@ -209,6 +208,7 @@ export default class extends moleculer.Service {
             RequestStatus.RETURNED,
             RequestStatus.DRAFT,
             RequestStatus.CREATED,
+            RequestStatus.REVIEW,
             RequestStatus.SUBMITTED,
           ].includes(request.status),
         };


### PR DESCRIPTION
Found a bug that when a Moleculer service  fields that are returned automatically, have a columnName property, it mismatches the naming (since this project auto turns snake_case into camelCase) and doesn't return the value automatically.